### PR TITLE
Making the top filters always visible and not hidden behind the left 

### DIFF
--- a/covid-19-support/src/components/Highlights.vue
+++ b/covid-19-support/src/components/Highlights.vue
@@ -161,12 +161,18 @@ export default {
 <style lang="scss">
 .highlights {
   margin: 4px !important;
+
   transition: height 0.25s ease-out;
   height: 116px;
 
   div.col-md-3 {
     padding: 0 !important;
   }
+}
+
+#wrapper.toggled .highlights {
+  transition: margin-left 0.25s ease-out;
+  margin-left: 294px !important;
 }
 
 @media (min-width: 768px) {

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -124,7 +124,7 @@ export default {
 .resultAddress {
   font-size: 0.8rem;
   display: block;
-  width: 17rem;
+  max-width: 262px;
 }
 .closedOne {
   /* background: #f9f9f9 !important; */

--- a/covid-19-support/src/components/SearchFilter.vue
+++ b/covid-19-support/src/components/SearchFilter.vue
@@ -139,6 +139,7 @@ export default {
   transition: margin 0.25s ease-out;
   z-index: 1035;
   max-height: 100vh;
+  max-width: 290px;
 }
 
 #wrapper.toggled #search-filter-wrapper {


### PR DESCRIPTION
This closes #106 

Rather than fixing the left, I have made the top search filters dynamic so that they resize if the left bar is visible or not.