### PR TITLE
Highlight: Show all numbers in categories regardless if marker is closed

### DIFF
--- a/covid-19-support/src/App.vue
+++ b/covid-19-support/src/App.vue
@@ -20,7 +20,7 @@
         <highlights
           :need="need"
           :class="{ toggled: isFilterOpen }"
-          :filteredMarkers="filteredMarkers"
+          :filteredMarkers="highlightFilteredMarkers"
           :highlightFilters="highlightFilters"
           @box-selected="boxSelected"
         />
@@ -193,6 +193,17 @@ export default {
       })
 
       return retList
+    },
+    highlightFilteredMarkers() {
+      if (!this.isAnyDaySelected(this.day)) {
+        return this.filteredMarkers
+      }
+
+      return this.filteredMarkers.map((m) => {
+        let obj = Object.assign({}, m)
+        obj.oc = true
+        return obj
+      })
     }
   }
 }


### PR DESCRIPTION
Commit 62b52ca ("Search Filter: Add "Any" option as a day selection
(#153)") allows users to select "any" day of the week to see what's
available to them. The problem is that the highlight component is
sensitive to markers that are closed or open. Because the "Any" day was
selected, we defaulted to showing the markers that were only open for
the users current day. Instead, we want to show all markers in the
highlight categories despite the current day.

Therefore, we create a separate computed property that object copies
markers, and sets them to open when the "Any" day is selected.