### PR TITLE
Search Filter: Default day selection to Any

### DIFF
--- a/covid-19-support/src/App.vue
+++ b/covid-19-support/src/App.vue
@@ -43,7 +43,7 @@ import Highlights from './components/Highlights.vue'
 import ResourceMap from './components/ResourceMap.vue'
 import AboutUsModal from './components/AboutUs.vue'
 
-import { spreadsheetUrl, weekdays, dayFilters, booleanFilters } from './constants'
+import { spreadsheetUrl, weekdays, dayFilters, booleanFilters, dayAny } from './constants'
 
 function extend(obj, src) {
   for (var key in src) {
@@ -88,7 +88,7 @@ export default {
     return {
       entries: null,
       need: 'none',
-      day: new Date().getDay(),
+      day: dayAny,
       isFilterOpen: true,
       language: { name: 'English', iso: 'en' },
       locationData: { locValue: null, isSetByMap: false },
@@ -108,7 +108,7 @@ export default {
       this.highlightFilters = addOrRemove(this.highlightFilters, content.need)
     },
     isAnyDaySelected(day) {
-      return day > 6
+      return day >= dayAny
     },
     needSelected: function (val) {
       this.need = val

--- a/covid-19-support/src/constants.js
+++ b/covid-19-support/src/constants.js
@@ -1,5 +1,7 @@
+export const dayAny = 7
+
 export const weekdays = [
-  { day: 'any', pos: 7 },
+  { day: 'any', pos: dayAny },
   { day: 'monday', pos: 1 },
   { day: 'tuesday', pos: 2 },
   { day: 'wednesday', pos: 3 },


### PR DESCRIPTION
Introduced in 62b52ca ("Search Filter: Add "Any" option as a day selection
(#153)"), but the dropdown menu would still select the users current day
as the default option. Instead, we want to make the selected day default
to "Any". Therefore, set the default day selection to "Any".

Lastly, create a constant for "dayAny" so we know that it's not a valid
day selection.