### PR TITLE
Add link to Google Maps in BusinessDetails

### DIFF
--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -21,7 +21,10 @@
           <p>
             <b>{{ $t('label.address') }}:</b><br />
             {{ business.marker.gsx$address.$t }}, {{ business.marker.gsx$city.$t }}, {{ business.marker.gsx$state.$t }}
-            {{ business.marker.gsx$zip.$t }}
+            {{ business.marker.gsx$zip.$t }}<br />
+            <a :href="'https://www.google.com/maps/search/?api=1&query=' + businessGoogleMapsUrl">
+              View on Google Maps
+            </a>
           </p>
 
           <p>
@@ -123,6 +126,18 @@ export default {
       return urlParts[0]
     },
     businessIcon: businessIcon
+  },
+  computed: {
+    businessGoogleMapsUrl() {
+      var url =
+        encodeURI(this.business.marker.gsx$providername.$t) +
+        '+' +
+        encodeURI(this.business.marker.gsx$address.$t) +
+        '+' +
+        encodeURI(this.business.marker.gsx$city.$t)
+
+      return url.replace(/%20/g, '+').toLowerCase()
+    }
   }
 }
 </script>
@@ -174,5 +189,9 @@ export default {
 
 .updated {
   color: #aaa;
+}
+
+a {
+  color: #ee8842 !important;
 }
 </style>

--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -22,7 +22,7 @@
             <b>{{ $t('label.address') }}:</b><br />
             {{ business.marker.gsx$address.$t }}, {{ business.marker.gsx$city.$t }}, {{ business.marker.gsx$state.$t }}
             {{ business.marker.gsx$zip.$t }}<br />
-            <a :href="'https://www.google.com/maps/search/?api=1&query=' + businessGoogleMapsUrl">
+            <a :href="businessGoogleMapsUrl">
               View on Google Maps
             </a>
           </p>
@@ -130,6 +130,7 @@ export default {
   computed: {
     businessGoogleMapsUrl() {
       var url =
+        'https://www.google.com/maps/search/?api=1&query=' +
         (this.business.marker.gsx$provideraddloc.$t
           ? encodeURI(this.business.marker.gsx$provideraddloc.$t)
           : encodeURI(this.business.marker.gsx$providername.$t)) +

--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -134,7 +134,11 @@ export default {
         '+' +
         encodeURI(this.business.marker.gsx$address.$t) +
         '+' +
-        encodeURI(this.business.marker.gsx$city.$t)
+        encodeURI(this.business.marker.gsx$city.$t) +
+        '+' +
+        encodeURI(this.business.marker.gsx$state.$t) +
+        '+' +
+        encodeURI(this.business.marker.gsx$zip.$t)
 
       return url.replace(/%20/g, '+').toLowerCase()
     }

--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -130,7 +130,9 @@ export default {
   computed: {
     businessGoogleMapsUrl() {
       var url =
-        encodeURI(this.business.marker.gsx$providername.$t) +
+        (this.business.marker.gsx$provideraddloc.$t
+          ? encodeURI(this.business.marker.gsx$provideraddloc.$t)
+          : encodeURI(this.business.marker.gsx$providername.$t)) +
         '+' +
         encodeURI(this.business.marker.gsx$address.$t) +
         '+' +


### PR DESCRIPTION
This places a link to the business on Google Maps below the address in the BusinessDetails panel.

There is no guarantee that the Google Maps link will return the right information as I am just querying Google Maps using the business name and address (instead of using something like Google Places).