### PR TITLE
add theme.config webpack alias for importing proper theme into vue

### DIFF
--- a/covid-19-support/.env
+++ b/covid-19-support/.env
@@ -1,6 +1,9 @@
 VUE_APP_I18N_LOCALE=en
 VUE_APP_I18N_FALLBACK_LOCALE=en
+<<<<<<< HEAD
 BASE_URL=/
 GA_ID=UA-162758783-1
 FB_ID=100447554971865
+=======
+>>>>>>> add theme.config webpack alias for importing proper theme into vue
 VUE_APP_THEME=NCCovidSupport

--- a/covid-19-support/src/App.vue
+++ b/covid-19-support/src/App.vue
@@ -52,7 +52,7 @@ import { haversineDistance, sortByDistance } from './utilities'
 
 import { weekdays, dayFilters, booleanFilters, dayAny } from './constants'
 
-import { theme } from './themes/NCCovidSupport/theme.config'
+import { theme } from 'theme.config'
 
 function extend(obj, src) {
   for (var key in src) {

--- a/covid-19-support/vue.config.js
+++ b/covid-19-support/vue.config.js
@@ -1,3 +1,9 @@
+const path = require('path')
+
+if (process.env.VUE_APP_THEME == null) {
+  throw new Error('Please provide VUE_APP_THEME environment variable')
+}
+
 const themePath = './src/themes/' + process.env.VUE_APP_THEME + '/'
 const themeContent = require(`${themePath}theme.content.js`)
 
@@ -29,8 +35,7 @@ module.exports = {
   configureWebpack: {
     resolve: {
       alias: {
-        // create alias for white label SCSS variable files
-        vueAppTheme: themePath
+        ['theme.config$']: path.resolve(__dirname, themePath + '/theme.config.js')
       }
     }
   },


### PR DESCRIPTION
There's currently a hardcoded reference in App.vue to the NCCovidSupport theme. This uses a Webpack alia to allow Vue to import `theme.config` from anywhere and get the current theme file based on the VUE_APP_THEME environment variable