### PR TITLE
Set map key to use SVG icons

### DIFF
--- a/covid-19-support/src/components/IconListItem.vue
+++ b/covid-19-support/src/components/IconListItem.vue
@@ -3,6 +3,7 @@
     <template v-if="link != ''">
       <div class="iconListItem">
         <div class="ilIcon">
+          <div class="leafletIcon" v-if="leafletIcon" v-html="generateIcon"></div>
           <i class="fas" v-bind:class="icon" v-if="icon != ''"></i>
           <img :src="image" v-if="icon == null || icon == ''" />
         </div>
@@ -17,6 +18,7 @@
     <template v-else>
       <div class="iconListItem">
         <div class="ilIcon">
+          <div class="leafletIcon" v-if="leafletIcon" v-html="generateIcon"></div>
           <i class="fas" v-bind:class="icon" v-if="icon != ''"></i>
           <img :src="image" v-if="icon == null || icon == ''" />
         </div>
@@ -37,10 +39,16 @@ export default {
     }
   },
   props: {
+    leafletIcon: {},
     title: { type: String },
     link: { type: String },
     icon: { type: String },
     image: { type: String }
+  },
+  computed: {
+    generateIcon() {
+      return this.leafletIcon.createIcon().outerHTML
+    }
   }
 }
 </script>
@@ -57,6 +65,17 @@ export default {
     color: theme-color('warning');
     @media (prefers-color-scheme: dark) {
       color: theme-color-level(warning, 5);
+    }
+  }
+
+  .leafletIcon {
+    margin: 0 0 0 0 !important;
+
+    & .leaflet-marker-icon {
+      position: static;
+      margin: 0 0 0 0 !important;
+      width: 32px !important;
+      height: 44px !important;
     }
   }
 }

--- a/covid-19-support/src/components/ResourceMap.vue
+++ b/covid-19-support/src/components/ResourceMap.vue
@@ -18,10 +18,8 @@
               <h6 class="title">{{ $t('label.mapkey') }}</h6>
               <i @click="showKey = !showKey" class="fas fa-info-circle" />
             </div>
-            <div class="keys" :class="{ 'show-key': showKey }">
-              <icon-list-item :image="require('../images/Blue.png')" :title="$t('label.open')" link="" />
-              <icon-list-item :image="require('../images/Grey.png')" :title="$t('label.closedonday')" link="" />
-              <icon-list-item :image="require('../images/Red.png')" :title="$t('label.selected')" link="" />
+            <div class="keys" :class="{ 'show-key': showKey }" v-for="item in mapKey" v-bind:key="item.title">
+              <icon-list-item :leaflet-icon="item.icon" :title="item.title" link="" />
             </div>
           </div>
         </l-control>
@@ -90,6 +88,39 @@ export default {
     this.$nextTick(() => {
       this.$emit('bounds', this.$refs.covidMap.mapObject.getBounds())
     })
+  },
+  computed: {
+    mapKey() {
+      return [
+        {
+          title: this.$t('label.open'),
+          icon: ExtraMarkers.icon({
+            className: 'markeropen',
+            icon: 'na',
+            prefix: 'fa',
+            svg: true
+          })
+        },
+        {
+          title: this.$t('label.closedonday'),
+          icon: ExtraMarkers.icon({
+            className: 'markerclosed',
+            icon: 'na',
+            prefix: 'fa',
+            svg: true
+          })
+        },
+        {
+          title: this.$t('label.selected'),
+          icon: ExtraMarkers.icon({
+            className: 'markerselected',
+            icon: 'na',
+            prefix: 'fa',
+            svg: true
+          })
+        }
+      ]
+    }
   },
   methods: {
     centerUpdated(center) {


### PR DESCRIPTION
Commit dd479e ("Adds business icons to leaflet markers #148 (#167)") changed
out the icons for the map to SVG based map icons. The map key icons no
longer match that on the map. We fix this by using the generator that
generates the SVG icons, and pass them to the IconListItem component.