### PR TITLE
Fixing content clipping issue

### DIFF
--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -102,7 +102,6 @@ export default {
 .resultItem {
   padding: 10px;
   display: block;
-  //min-height: 100px;
   border-bottom: solid 1px rgba(0, 0, 0, 0.125);
   font-size: 0.8rem;
   max-width: 282px;

--- a/covid-19-support/src/components/ResultsList.vue
+++ b/covid-19-support/src/components/ResultsList.vue
@@ -102,7 +102,7 @@ export default {
 .resultItem {
   padding: 10px;
   display: block;
-  min-height: 100px;
+  //min-height: 100px;
   border-bottom: solid 1px rgba(0, 0, 0, 0.125);
   font-size: 0.8rem;
   max-width: 282px;


### PR DESCRIPTION
I noticed that for businesses with more than 3 lines of text, the icons on the bottom were getting cropped. This should fix it!

<img width="294" alt="screen_shot_2020-06-04_at_12 46 04_pm" src="https://user-images.githubusercontent.com/43389857/83819358-a3681000-a697-11ea-8b51-6a902c413739.png">

<img width="294" alt="Screen Shot 2020-06-04 at 7 12 26 PM" src="https://user-images.githubusercontent.com/43389857/83819338-9c410200-a697-11ea-88d8-ccdef8fe9b4c.png">
