### PR TITLE
Simple implementation of directions button, links out to google maps

### DIFF
--- a/covid-19-support/src/components/BusinessDetails.vue
+++ b/covid-19-support/src/components/BusinessDetails.vue
@@ -20,6 +20,7 @@
           <p v-if="getAddress(business.marker) !== ''">
             <b>{{ $t('label.address') }}:</b><br />
             {{ getAddress(business.marker) }}
+            <icon-list-item icon="fa fa-directions" :title="$t('getdirections')" :link="directionsLink(addressURL(business.marker))" />
           </p>
           <p>
             <icon-list-item
@@ -143,6 +144,17 @@ export default {
     getDomain: function (url) {
       var urlParts = url.replace('http://', '').replace('https://', '').replace('www.', '').split(/[/?#]/)
       return urlParts[0]
+    },
+    addressURL: function (marker) {
+      var address = marker.gsx$address.$t
+      address = address.replace(/\s/g, '%20')
+      var city = marker.gsx$city.$t.replace(/\s/g, '%20')
+      var state = marker.gsx$state.$t.replace(/\s/g, '%20')
+      address = address + '%2C%20' + city + '%2C%20' + state + '%20' + marker.gsx$zip.$t
+      return address
+    },
+    directionsLink: function (address) {
+      return 'https://www.google.com/maps/dir/?api=1&destination=' + address
     },
     businessIcon: businessIcon,
     getAddress: getAddress

--- a/covid-19-support/src/locales/en.json
+++ b/covid-19-support/src/locales/en.json
@@ -122,5 +122,6 @@
     "what-do-you-need": "What do you need?",
     "when-do-you-need-it": "When do you need it?"
   },
-  "title": "{0} COVID Support"
+  "title": "{0} COVID Support",
+  "getdirections": "Get directions"
 }


### PR DESCRIPTION
This is the initial implementation of issue 243, with a get directions button that links to google maps. Example of what button looks like below:

<img width="1414" alt="Screen Shot 2020-06-26 at 2 47 46 PM" src="https://user-images.githubusercontent.com/43389857/85890778-0a22aa00-b7bc-11ea-8033-d17f6c351ce1.png">

Working with @readingdancer to add in Google Maps, Apple Maps, and Waze options so we can see what that would look like/if that's something we want to include, so I'm going to leave the issue open for now, but if this looks okay we can merge it in to start.